### PR TITLE
support psalm 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "ext-simplexml": "*",
-        "vimeo/psalm": "4.*"
+        "vimeo/psalm": "^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.5",


### PR DESCRIPTION
As far as i can see there are no BC breaks affecting the plugin. 
So i don't think there is anything wrong with supporting psalm 5.x as well.