### PR TITLE
Allow installation of psalm 6, Drop PHP 8.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
+          php-version: 8.1
       - uses: ramsey/composer-install@v1
       - run: composer check

--- a/composer.json
+++ b/composer.json
@@ -6,16 +6,16 @@
     "require": {
         "php": "^8.0",
         "ext-simplexml": "*",
-        "vimeo/psalm": "5.*"
+        "vimeo/psalm": "^5.0.0|^6.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.5",
-        "squizlabs/php_codesniffer": "^3.3",
-        "psalm/plugin-phpunit": "^0.18",
-        "weirdan/prophecy-shim": "^2.0",
-        "weirdan/codeception-psalm-module": "^0.13.1",
-        "codeception/codeception": "^4.1",
-        "behat/behat": "^3.11"
+        "phpunit/phpunit": "^10.5.40",
+        "squizlabs/php_codesniffer": "^3.11.3",
+        "psalm/plugin-phpunit": "^0.19.2",
+        "weirdan/prophecy-shim": "^2.0.2",
+        "weirdan/codeception-psalm-module": "^0.14.0",
+        "codeception/codeception": "^5.1.2",
+        "behat/behat": "^3.18.1"
     },
     "extra": {
         "psalm": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "psalm-plugin",
     "license": "MIT",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-simplexml": "*",
         "vimeo/psalm": "^5.0.0|^6.0.0"
     },

--- a/src/AllowInheritance.php
+++ b/src/AllowInheritance.php
@@ -4,6 +4,7 @@ namespace Cspray\Phinal;
 
 use Attribute;
 
+/** @psalm-suppress UnusedClass */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class AllowInheritance
 {

--- a/src/AllowInheritance.php
+++ b/src/AllowInheritance.php
@@ -4,7 +4,7 @@ namespace Cspray\Phinal;
 
 use Attribute;
 
-/** @psalm-suppress UnusedClass */
+/** @api */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class AllowInheritance
 {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -3,46 +3,26 @@
 namespace Cspray\Phinal;
 
 use PhpParser\Node;
-use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\AfterClassLikeAnalysisInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent;
-use Psalm\StatementsSource;
-use Psalm\Storage\ClassLikeStorage;
 use SimpleXMLElement;
 use Psalm\Plugin\PluginEntryPointInterface;
 use Psalm\Plugin\RegistrationInterface;
 
+/** @psalm-suppress UnusedClass */
 class Plugin implements PluginEntryPointInterface, AfterClassLikeAnalysisInterface
 {
     /** @return void */
     public function __invoke(RegistrationInterface $psalm, ?SimpleXMLElement $config = null): void
     {
-        // This is plugin entry point. You can initialize things you need here,
-        // and hook them into psalm using RegistrationInterface
-        //
-        // Here's some examples:
-        // 1. Add a stub file
-        // ```php
-        // $psalm->addStubFile(__DIR__ . '/stubs/YourStub.php');
-        // ```
-        foreach ($this->getStubFiles() as $file) {
-            $psalm->addStubFile($file);
-        }
-
         // Psalm allows arbitrary content to be stored under you plugin entry in
         // its config file, psalm.xml, so your plugin users can put some configuration
         // values there. They will be provided to your plugin entry point in $config
         // parameter, as a SimpleXmlElement object. If there's no configuration present,
         // null will be passed instead.
         $psalm->registerHooksFromClass($this::class);
-    }
-
-    /** @return list<string> */
-    private function getStubFiles(): array
-    {
-        return glob(__DIR__ . '/stubs/*.phpstub') ?: [];
     }
 
     public static function afterStatementAnalysis(AfterClassLikeAnalysisEvent $event)

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -17,6 +17,7 @@ namespace Weirdan\PsalmPluginSkeleton\Tests;
  *
  * @SuppressWarnings(PHPMD)
  * @psalm-suppress UndefinedTrait
+ * @psalm-suppress UnusedClass
 */
 class AcceptanceTester extends \Codeception\Actor
 {

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -5,6 +5,7 @@ namespace Weirdan\PsalmPluginSkeleton\Tests\Helper;
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 
+/** @psalm-suppress UnusedClass */
 class Acceptance extends \Codeception\Module
 {
 }

--- a/tests/acceptance/MyTest.feature
+++ b/tests/acceptance/MyTest.feature
@@ -33,6 +33,7 @@ Feature: basics
       """
       <?php
 
+      /** @psalm-suppress UnusedClass */
       abstract class AbstractClass {}
       """
     When I run Psalm
@@ -43,6 +44,7 @@ Feature: basics
       """
       <?php
 
+      /** @psalm-suppress UnusedClass */
       interface SomeInterface {}
       """
     When I run Psalm
@@ -53,6 +55,7 @@ Feature: basics
       """
       <?php
 
+      /** @psalm-suppress UnusedClass */
       final class SomeFinalClass {}
       """
     When I run Psalm
@@ -65,7 +68,7 @@ Feature: basics
 
       interface SomeInterface {}
 
-      $class = new class implements SomeInterface {};
+      $_class = new class implements SomeInterface {};
       """
     When I run Psalm
     Then I see no errors
@@ -77,6 +80,7 @@ Feature: basics
 
       use Cspray\Phinal\AllowInheritance;
 
+      /** @psalm-suppress UnusedClass */
       #[AllowInheritance('We are allowing inheritance because we could not figure out how to use composition')]
       class SomeClassThatGetsInherited {}
       """


### PR DESCRIPTION
I removed the stub logic alltogether since it was not used, added some supresses to satify pslam as it seems this is the way to go here, otherwise i would have created a baseline for them.